### PR TITLE
Feature/dropdown only

### DIFF
--- a/src/Controller/PageFrontendController.php
+++ b/src/Controller/PageFrontendController.php
@@ -48,6 +48,18 @@ class PageFrontendController extends AbstractController
             'You must log in to view this page.'
         );
 
+        if ($page->isDropdownOnly()) {
+            $children = $page->getPages();
+
+            foreach ($children as $child) {
+                if ($child->isPublished()) {
+                    return $this->redirectToRoute('oh_media_page_frontend', [
+                        'path' => $child->getPath(),
+                    ], 301);
+                }
+            }
+        }
+
         if ($page->isRedirectTypeInternal()) {
             return $this->redirectToRoute('oh_media_page_frontend', [
                 'path' => $page->getRedirectInternal()->getPath(),

--- a/src/Controller/PageFrontendController.php
+++ b/src/Controller/PageFrontendController.php
@@ -48,16 +48,10 @@ class PageFrontendController extends AbstractController
             'You must log in to view this page.'
         );
 
-        if ($page->isDropdownOnly()) {
-            $children = $page->getPages();
-
-            foreach ($children as $child) {
-                if ($child->isPublished()) {
-                    return $this->redirectToRoute('oh_media_page_frontend', [
-                        'path' => $child->getPath(),
-                    ], 301);
-                }
-            }
+        if ($redirectPage = $this->getDropdownOnlyRedirect()) {
+            return $this->redirectToRoute('oh_media_page_frontend', [
+                'path' => $redirectPage->getPath(),
+            ], 301);
         }
 
         if ($page->isRedirectTypeInternal()) {

--- a/src/Controller/PageFrontendController.php
+++ b/src/Controller/PageFrontendController.php
@@ -48,7 +48,7 @@ class PageFrontendController extends AbstractController
             'You must log in to view this page.'
         );
 
-        if ($redirectPage = $this->getDropdownOnlyRedirect()) {
+        if ($redirectPage = $page->getDropdownOnlyRedirect()) {
             return $this->redirectToRoute('oh_media_page_frontend', [
                 'path' => $redirectPage->getPath(),
             ], 301);

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -28,7 +28,6 @@ class SitemapController extends AbstractController
             ->andWhere('(p.redirect_type = :redirect_type_none OR p.redirect_type IS NULL)')
             ->setParameter('redirect_type_none', Page::REDIRECT_TYPE_NONE)
             ->andWhere('p.noindex = 0')
-            ->andWhere('p.locked = 0')
             ->orderBy('p.order_global', 'asc')
             ->getQuery()
             ->getResult();

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -39,7 +39,7 @@ class SitemapController extends AbstractController
                 continue;
             }
 
-            if ($this->getDropdownOnlyRedirect()) {
+            if ($page->getDropdownOnlyRedirect()) {
                 continue;
             }
 

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -28,6 +28,7 @@ class SitemapController extends AbstractController
             ->andWhere('(p.redirect_type = :redirect_type_none OR p.redirect_type IS NULL)')
             ->setParameter('redirect_type_none', Page::REDIRECT_TYPE_NONE)
             ->andWhere('p.noindex = 0')
+            ->andWhere('p.locked = 0')
             ->orderBy('p.order_global', 'asc')
             ->getQuery()
             ->getResult();

--- a/src/Controller/SitemapController.php
+++ b/src/Controller/SitemapController.php
@@ -39,6 +39,10 @@ class SitemapController extends AbstractController
                 continue;
             }
 
+            if ($this->getDropdownOnlyRedirect()) {
+                continue;
+            }
+
             $pageRevision = $page->getCurrentPageRevision();
 
             $path = $page->isHomepage() ? '' : $page->getPath();

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -128,6 +128,9 @@ class Page
     #[ORM\Column(nullable: true)]
     private ?array $locked_user_types = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?bool $dropdown_only = null;
+
     public function __construct()
     {
         $this->pages = new ArrayCollection();
@@ -696,6 +699,18 @@ class Page
     public function setLockedUserTypes(?array $locked_user_types): static
     {
         $this->locked_user_types = $locked_user_types;
+
+        return $this;
+    }
+
+    public function isDropdownOnly(): ?bool
+    {
+        return $this->dropdown_only;
+    }
+
+    public function setDropdownOnly(?bool $dropdown_only): static
+    {
+        $this->dropdown_only = $dropdown_only;
 
         return $this;
     }

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -714,4 +714,33 @@ class Page
 
         return $this;
     }
+
+    public function getDropdownOnlyRedirect(): ?Page
+    {
+        if (!$this->isDropdownOnly()) {
+            return null;
+        }
+
+        $children = $this->getPages();
+
+        if ($this->isLocked()) {
+            // if $this parent page is locked
+            // then we only care about the first published child
+            foreach ($children as $child) {
+                if ($child->isPublished()) {
+                    return $child;
+                }
+            }
+        } else {
+            // if $this parent page is not locked
+            // then we only care about the first publicly accessible child
+            foreach ($children as $child) {
+                if ($child->isVisibleToPublic()) {
+                    return $child;
+                }
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Form/PageNavigationType.php
+++ b/src/Form/PageNavigationType.php
@@ -36,6 +36,11 @@ class PageNavigationType extends AbstractType
                 'help' => 'If this page has children, this text will be used in the main nav dropdown.<br><b>Default value:</b> '.$page->getName(),
                 'help_html' => true,
             ])
+            ->add('dropdown_only', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Use as dropdown only',
+                'help' => 'If this page has children and this option is checked, the navigation will not contain a link to this page and if a user tries to navigate to this page, they will be redirected to the first available child page.',
+            ])
             ->add('new_window', CheckboxType::class, [
                 'required' => false,
                 'label' => 'Open in a new window in navigation menu',
@@ -43,6 +48,7 @@ class PageNavigationType extends AbstractType
             ->add('hidden', CheckboxType::class, [
                 'required' => false,
                 'label' => 'Exclude from navigation',
+                'help' => 'Child pages will also be excluded from navigation.',
             ])
             ->add('redirect_type', ChoiceType::class, [
                 'choices' => [

--- a/templates/nav.html.twig
+++ b/templates/nav.html.twig
@@ -14,18 +14,21 @@
         {{ nav_item.dropdown_text }}
       </a>
       <ul class="dropdown-menu nav--level-{{ nesting_level }}">
-        <li>
-          <a
-            href="{{ nav_item.href }}"
-            {% if page.isNewWindow %}target="_blank" rel="noopener"{% endif %}
-            class="dropdown-item {{ nav_item.active ? 'active' : '' }}"
-            {% if nav_item.active %}aria-current{% endif %}
-          >
-            {{ nav_item.text }}
-          </a>
-        </li>
+        {% if not page.dropdownOnly %}
+          <li>
+            <a
+              href="{{ nav_item.href }}"
+              {% if page.isNewWindow %}target="_blank" rel="noopener"{% endif %}
+              class="dropdown-item {{ nav_item.active ? 'active' : '' }}"
+              {% if nav_item.active %}aria-current{% endif %}
+            >
+              {{ nav_item.text }}
+            </a>
+          </li>
+        {% endif %}
+
         {% for child_nav_item in nav_item.children %}
-        {{ _self.page_nav(child_nav_item, nesting_level + 1) }}
+          {{ _self.page_nav(child_nav_item, nesting_level + 1) }}
         {% endfor %}
       </ul>
     </li>


### PR DESCRIPTION
Added an option to flag a page as dropdown only. This means if the page has children and the nav will render a dropdown, there will be no link to that page under the dropdown. The parent page will also be redirect to an appropriate child page if possible.

Updated the sitemap to exclude the dropdown only page as needed.

No need to update the logic for the canonical path of the page if it will be redirected.