### PR TITLE
Feature/accessibility

### DIFF
--- a/src/Form/PageCreateType.php
+++ b/src/Form/PageCreateType.php
@@ -24,6 +24,9 @@ class PageCreateType extends AbstractType
                 'required' => false,
                 'help' => 'Leave this blank to auto-generate based on the Name.',
                 'empty_data' => '',
+                'attr' => [
+                    'aria-label' => 'Page Slug',
+                ],
             ])
             ->add('parent', EntityType::class, [
                 'label' => 'Parent Page',
@@ -40,6 +43,7 @@ class PageCreateType extends AbstractType
                     ->orderBy('p.order_global', 'ASC'),
                 'attr' => [
                     'style' => 'direction:rtl',
+                    'aria-label' => 'Parent Page',
                 ],
             ])
         ;

--- a/src/Form/PageEditType.php
+++ b/src/Form/PageEditType.php
@@ -46,6 +46,9 @@ class PageEditType extends AbstractType
                 'required' => false,
                 'help' => 'Leave this blank to auto-generate based on the Name.',
                 'empty_data' => '',
+                'attr' => [
+                    'aria-label' => 'Page Slug',
+                ],
             ])
             ->add('locked', CheckboxType::class, [
                 'required' => false,

--- a/src/Form/Type/AbstractPageTemplateType.php
+++ b/src/Form/Type/AbstractPageTemplateType.php
@@ -79,6 +79,12 @@ abstract class AbstractPageTemplateType extends AbstractType
             'class' => 'fieldset-nostyle',
         ];
 
+        $options['choice_label'] = !empty($options['label'])
+            ? $options['label']
+            : $this->generateLabel($name);
+
+        $options['label'] = false;
+
         return $this->addPageContent(
             $name,
             PageContentChoiceType::class,
@@ -123,6 +129,12 @@ abstract class AbstractPageTemplateType extends AbstractType
             'class' => 'fieldset-nostyle',
         ];
 
+        $options['text_label'] = !empty($options['label'])
+            ? $options['label']
+            : $this->generateLabel($name);
+
+        $options['label'] = false;
+
         return $this->addPageContent(
             $name,
             PageContentTextType::class,
@@ -137,6 +149,12 @@ abstract class AbstractPageTemplateType extends AbstractType
             'class' => 'fieldset-nostyle',
         ];
 
+        $options['textarea_label'] = !empty($options['label'])
+            ? $options['label']
+            : $this->generateLabel($name);
+
+        $options['label'] = false;
+
         return $this->addPageContent(
             $name,
             PageContentTextareaType::class,
@@ -150,6 +168,12 @@ abstract class AbstractPageTemplateType extends AbstractType
         $options['row_attr'] = [
             'class' => 'fieldset-nostyle',
         ];
+
+        $options['wysiwyg_label'] = !empty($options['label'])
+            ? $options['label']
+            : $this->generateLabel($name);
+
+        $options['label'] = false;
 
         return $this->addPageContent(
             $name,

--- a/src/Form/Type/PageContentChoiceType.php
+++ b/src/Form/Type/PageContentChoiceType.php
@@ -17,7 +17,7 @@ class PageContentChoiceType extends AbstractType
 
         $builder
             ->add('text', ChoiceType::class, [
-                'label' => false,
+                'label' => $options['choice_label'],
                 'required' => $options['required'],
                 'data' => $content ? $content->getText() : null,
                 'attr' => $options['choice_attr'],
@@ -43,6 +43,7 @@ class PageContentChoiceType extends AbstractType
             'choice_attr' => [],
             'choice_choices' => [],
             'choice_expanded' => false,
+            'choice_label' => null,
         ]);
     }
 }

--- a/src/Form/Type/PageContentTextType.php
+++ b/src/Form/Type/PageContentTextType.php
@@ -17,7 +17,7 @@ class PageContentTextType extends AbstractType
 
         $builder
             ->add('text', TextType::class, [
-                'label' => false,
+                'label' => $options['text_label'],
                 'required' => $options['required'],
                 'data' => $content ? $content->getText() : null,
                 'attr' => $options['text_attr'],
@@ -36,6 +36,7 @@ class PageContentTextType extends AbstractType
         $resolver->setDefaults([
             'data_class' => PageContentText::class,
             'text_attr' => [],
+            'text_label' => null,
         ]);
     }
 }

--- a/src/Form/Type/PageContentTextareaType.php
+++ b/src/Form/Type/PageContentTextareaType.php
@@ -17,7 +17,7 @@ class PageContentTextareaType extends AbstractType
 
         $builder
             ->add('text', TextareaType::class, [
-                'label' => false,
+                'label' => $options['textarea_label'],
                 'required' => $options['required'],
                 'data' => $content ? $content->getText() : null,
                 'attr' => $options['textarea_attr'],
@@ -36,6 +36,7 @@ class PageContentTextareaType extends AbstractType
         $resolver->setDefaults([
             'data_class' => PageContentText::class,
             'textarea_attr' => [],
+            'textarea_label' => null,
         ]);
     }
 }

--- a/src/Form/Type/PageContentWysiwygType.php
+++ b/src/Form/Type/PageContentWysiwygType.php
@@ -17,7 +17,7 @@ class PageContentWysiwygType extends AbstractType
 
         $builder
             ->add('text', WysiwygType::class, [
-                'label' => false,
+                'label' => $options['wysiwyg_label'],
                 'data' => $content ? $content->getText() : null,
                 'attr' => $options['wysiwyg_attr'],
                 'allowed_tags' => $options['allowed_tags'],
@@ -37,6 +37,7 @@ class PageContentWysiwygType extends AbstractType
         $resolver->setDefaults([
             'data_class' => PageContentText::class,
             'wysiwyg_attr' => [],
+            'wysiwyg_label' => null,
             'allowed_tags' => null,
             'allow_shortcodes' => true,
         ]);

--- a/src/Service/PageQueryBuilder.php
+++ b/src/Service/PageQueryBuilder.php
@@ -5,6 +5,7 @@ namespace OHMedia\PageBundle\Service;
 use Doctrine\ORM\QueryBuilder;
 use OHMedia\PageBundle\Entity\Page;
 use OHMedia\PageBundle\Repository\PageRepository;
+use OHMedia\TimezoneBundle\Util\DateTimeUtil;
 
 class PageQueryBuilder
 {
@@ -125,13 +126,13 @@ class PageQueryBuilder
         if ($this->published) {
             $this->queryBuilder
                 ->andWhere("$field IS NOT NULL")
-                ->andWhere("$field >= :publishedSince")
-                ->setParameter('publishedSince', new \DateTime())
+                ->andWhere("$field <= :now")
+                ->setParameter('now', DateTimeUtil::getDateTimeUtc())
             ;
         } else {
             $this->queryBuilder
-                ->andWhere("($field IS NULL OR $field < :publishedSince)")
-                ->setParameter('publishedSince', new \DateTime())
+                ->andWhere("($field IS NULL OR $field > :now)")
+                ->setParameter('now', DateTimeUtil::getDateTimeUtc())
             ;
         }
     }

--- a/templates/page/_page_actions_shared.html.twig
+++ b/templates/page/_page_actions_shared.html.twig
@@ -53,21 +53,6 @@
         </li>
       {% endif %}
 
-      {% if is_granted(attributes.page.publish, page) %}
-        <li>
-          {% embed '@OHMediaBackend/embed/form_post_confirm.html.twig' %}
-            {% block form_action %}{{ path('page_publish', {id: page.id}) }}{% endblock %}
-            {% block confirm_message %}Are you sure you want to publish this page?{% if page.published %} This page will be published automatically on <i>{{ page.published|date('M j, Y') }}</i> at <i>{{ page.published|date('g:ia') }}</i>.{% endif %}{% endblock %}
-            {% block csrf_name %}publish_page_{{ page.id }}{% endblock %}
-            {% block button_class %}dropdown-item text-bg-success{% endblock %}
-            {% block button_html %}
-              {{ bootstrap_icon('check') }}
-              Publish
-            {% endblock %}
-          {% endembed %}
-        </li>
-      {% endif %}
-
       {% if is_granted(attributes.page.unpublish, page) %}
         <li>
           {% embed '@OHMediaBackend/embed/form_post_confirm.html.twig' %}

--- a/templates/page/_page_revision_actions.html.twig
+++ b/templates/page/_page_revision_actions.html.twig
@@ -1,0 +1,98 @@
+{% macro page_revision_icon(page_revision, current_page_revision) %}
+  {% if page_revision.isPublished %}
+    {% if current_page_revision == page_revision %}
+    {{ bootstrap_badge_primary('Live') }}
+    {% else %}
+    {{ bootstrap_badge_success('Published') }}
+    {% endif %}
+  {% else %}
+    {{ bootstrap_badge_warning('Draft') }}
+  {% endif %}
+{% endmacro %}
+
+<div id="select_revision_label" class="fw-bold">Choose Revision:</div>
+
+<div class="d-flex flex-wrap gap-1 mb-4">
+  <div class="dropdown" role="group" aria-labelledby="select_revision_label">
+    <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      {{ _self.page_revision_icon(preview_page_revision, current_page_revision) }}
+      {{ preview_page_revision }}
+    </button>
+    <ul class="dropdown-menu">
+      {% for page_revision in page.pageRevisions %}
+        <li>
+          <a class="dropdown-item {{ page_revision == preview_page_revision ? 'disabled' : '' }}" href="{{ path('page_view', {id: page.id, revision: page_revision.id}) }}">
+            {{ _self.page_revision_icon(page_revision, current_page_revision) }}
+            {{ page_revision }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  {% set show_publish = (not preview_page_revision.isPublished or current_page_revision != preview_page_revision) and is_granted(attributes.page_revision.publish, preview_page_revision) %}
+
+  {% set show_content = is_granted(attributes.page_revision.content, preview_page_revision) %}
+
+  <div class="dropdown" role="group">
+    <button class="btn btn-sm btn-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Revision Actions
+    </button>
+    <ul class="dropdown-menu">
+      {% if is_granted(attributes.page_revision.template, preview_page_revision) %}
+        <li>
+          <a href="{{ path('page_revision_template', {id: preview_page_revision.id}) }}" class="dropdown-item">
+            {{ bootstrap_icon('columns') }}
+            Template
+          </a>
+        </li>
+      {% endif %}
+
+      {% if show_content %}
+        <li>
+          <a href="{{ path('page_revision_content', {id: preview_page_revision.id}) }}" class="dropdown-item">
+            {{ bootstrap_icon('layout-text-sidebar-reverse') }}
+            Content
+          </a>
+        </li>
+      {% endif %}
+
+      {% if show_publish and preview_page_revision.isPublished %}
+        <li>
+          {% embed '@OHMediaBackend/embed/form_post_confirm.html.twig' %}
+            {% block form_action %}{{ path('page_revision_publish', {id: preview_page_revision.id}) }}{% endblock %}
+            {% block confirm_message %}Are you sure you want to re-publish this revision? It will become the new live page!{% endblock %}
+            {% block csrf_name %}publish_page_revision_{{ preview_page_revision.id }}{% endblock %}
+            {% block button_class %}dropdown-item text-bg-success{% endblock %}
+            {% block button_html %}
+              {{ bootstrap_icon('check') }}
+              Re-Publish
+            {% endblock %}
+          {% endembed %}
+        </li>
+      {% endif %}
+
+      {% if is_granted(attributes.page_revision.delete, preview_page_revision) %}
+        <li>
+          <a href="{{ path('page_revision_delete', {id: preview_page_revision.id}) }}" class="dropdown-item text-bg-danger" data-confirm="Are you sure you want to delete this revision?">
+            {{ bootstrap_icon('trash') }}
+            Delete
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </div>
+
+  {% if show_publish and not preview_page_revision.isPublished %}
+    {% embed '@OHMediaBackend/embed/form_post_confirm.html.twig' %}
+      {% block form_action %}{{ path('page_revision_publish', {id: preview_page_revision.id}) }}{% endblock %}
+      {% block confirm_message %}Are you sure you want to publish this revision? It will become the new live page!{% endblock %}
+      {% block csrf_name %}publish_page_revision_{{ preview_page_revision.id }}{% endblock %}
+      {% block button_class %}btn btn-success btn-sm{% endblock %}
+      {% block button_html %}
+        {{ bootstrap_icon('check') }}
+        Publish Revision
+      {% endblock %}
+    {% endembed %}
+  {% endif %}
+</div>

--- a/templates/page/page_create.html.twig
+++ b/templates/page/page_create.html.twig
@@ -21,9 +21,13 @@
               <label class="form-label">Path</label>
               <div class="input-group">
                 {{ form_widget(form.parent) }}
-                {{ form_widget(form.slug) }}
+                {{ form_widget(form.slug, {
+                  attr: {
+                    'aria-description': 'Leave this input blank to auto-generate a value.',
+                  },
+                }) }}
               </div>
-              <p class="form-text mb-0 help-text">
+              <p class="form-text mb-0 help-text" aria-hidden="true">
                 Leave the second input blank to auto-generate a value.
               </p>
               {{ form_errors(form.slug) }}

--- a/templates/page/page_edit.html.twig
+++ b/templates/page/page_edit.html.twig
@@ -30,9 +30,13 @@
                 <span class="input-group-text">
                   {{ page.parent ? page.parent.path : '' }}/
                 </span>
-                {{ form_widget(form.slug) }}
+                {{ form_widget(form.slug, {
+                  attr: {
+                    'aria-description': 'Leave this input blank to auto-generate a value.',
+                  },
+                }) }}
               </div>
-              <p class="form-text mb-0 help-text">
+              <p class="form-text mb-0 help-text" aria-hidden="true">
                 Leave this blank to auto-generate a value.
                 {% if page.isHomepage %}
                   <br /><i><b>Note:</b> changing the path of the homepage has no effect.</i>

--- a/templates/page/page_index.html.twig
+++ b/templates/page/page_index.html.twig
@@ -117,9 +117,8 @@
     </td>
     <td>
       {% if page.isHomepage %}
-        <span class="badge text-bg-dark" title="Homepage">
+        <span class="badge text-bg-dark" title="Homepage" aria-label="This is the homepage.">
           {{ bootstrap_icon('house') }}
-          <span class="visually-hidden">Homepage</span>
         </span>
       {% endif %}
 
@@ -130,23 +129,20 @@
       {% endif %}
 
       {% if page.isHidden %}
-        <span class="badge text-bg-dark" title="Hidden">
+        <span class="badge text-bg-dark" title="Hidden" aria-label="This page is hidden from navigation.">
           {{ bootstrap_icon('eye-slash') }}
-          <span class="visually-hidden">Hidden</span>
         </span>
       {% endif %}
 
       {% if page.isLocked %}
-        <span class="badge text-bg-dark" title="Login Required">
+        <span class="badge text-bg-dark" title="Login Required" aria-label="This page requires login.">
           {{ bootstrap_icon('lock') }}
-          <span class="visually-hidden">Login Required</span>
         </span>
       {% endif %}
 
       {% if page.isNewWindow %}
-        <span class="badge text-bg-dark" title="New Window">
+        <span class="badge text-bg-dark" title="New Window" aria-label="This page opens in a new window from navigation.">
           {{ bootstrap_icon('box-arrow-up-right') }}
-          <span class="visually-hidden">New Window</span>
         </span>
       {% endif %}
     </td>

--- a/templates/page/page_index.html.twig
+++ b/templates/page/page_index.html.twig
@@ -65,7 +65,7 @@
                 <th>User Types</th>
               {% endif %}
               <th>Last Updated</th>
-              <th>&nbsp;</th>
+              <th aria-label="Row Actions"></th>
             </tr>
           </thead>
           <tbody>

--- a/templates/page/page_reorder.html.twig
+++ b/templates/page/page_reorder.html.twig
@@ -18,14 +18,17 @@
         <input type="checkbox" class="form-check-input" id="page-tree-checkbox-{{ page.id }}" />
         <label class="form-check-label" for="page-tree-checkbox-{{ page.id }}">
           {{ page.name }}
+
           {% if page.isHidden %}
-          {{ bootstrap_icon('eye-slash') }}
+            {{ bootstrap_icon('eye-slash') }}
           {% endif %}
+
           {% if page.isLocked %}
-          {{ bootstrap_icon('lock') }}
+            {{ bootstrap_icon('lock') }}
           {% endif %}
+
           {% if page.isNewWindow %}
-          {{ bootstrap_icon('box-arrow-up-right') }}
+            {{ bootstrap_icon('box-arrow-up-right') }}
           {% endif %}
         </label>
       </div>

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -92,6 +92,8 @@
 {% endblock %}
 
 {% block main %}
+  <h1 class="visually-hidden">{{ page.name }} {{ preview_page_revision }}</h1>
+
   <div id="select_revision_label" class="fw-bold">Choose Revision:</div>
   <div class="dropdown d-inline-block mb-4" role="group" aria-labelledby="select_revision">
     <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -82,6 +82,19 @@
     </a>
   {% endif %}
 
+  {% if is_granted(attributes.page.publish, page) %}
+    {% embed '@OHMediaBackend/embed/form_post_confirm.html.twig' %}
+      {% block form_action %}{{ path('page_publish', {id: page.id}) }}{% endblock %}
+      {% block confirm_message %}Are you sure you want to publish this page?{% if page.published %} This page will be published automatically on <i>{{ page.published|date('M j, Y') }}</i> at <i>{{ page.published|date('g:ia') }}</i>.{% endif %}{% endblock %}
+      {% block csrf_name %}publish_page_{{ page.id }}{% endblock %}
+      {% block button_class %}btn btn-success{% endblock %}
+      {% block button_html %}
+        {{ bootstrap_icon('check') }}
+        Publish Page
+      {% endblock %}
+    {% endembed %}
+  {% endif %}
+
   {% include '@OHMediaPage/page/_page_actions_shared.html.twig' with {
     simple: false,
   } %}

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -10,41 +10,37 @@
       </li>
       <li class="breadcrumb-item active" aria-current="page">
         {% if page.isHomepage %}
-        <span class="badge text-bg-dark" title="Homepage">
-          {{ bootstrap_icon('house') }}
-          <span class="visually-hidden">Homepage</span>
-        </span>
+          <span class="badge text-bg-dark" title="Homepage" aria-label="This is the homepage.">
+            {{ bootstrap_icon('house') }}
+          </span>
         {% endif %}
 
         {% if page.isPublished %}
-        <span class="badge text-bg-success" title="Published">
-          {{ page.name }}
-        </span>
+          <span class="badge text-bg-success" title="Published">
+            {{ page.name }}
+          </span>
         {% else %}
-        <span class="badge text-bg-warning" title="Draft">
-          {{ page.name }}
-        </span>
+          <span class="badge text-bg-warning" title="Draft">
+            {{ page.name }}
+          </span>
         {% endif %}
 
         {% if page.isHidden %}
-        <span class="badge text-bg-dark" title="Hidden">
-          {{ bootstrap_icon('eye-slash') }}
-          <span class="visually-hidden">Hidden</span>
-        </span>
+          <span class="badge text-bg-dark" title="Hidden" aria-label="This page is hidden from navigation.">
+            {{ bootstrap_icon('eye-slash') }}
+          </span>
         {% endif %}
 
         {% if page.isLocked %}
-        <span class="badge text-bg-dark" title="Locked">
-          {{ bootstrap_icon('lock') }}
-          <span class="visually-hidden">Locked</span>
-        </span>
+          <span class="badge text-bg-dark" title="Login Required" aria-label="This page requires login.">
+            {{ bootstrap_icon('lock') }}
+          </span>
         {% endif %}
 
         {% if page.isNewWindow %}
-        <span class="badge text-bg-dark" title="New Window">
-          {{ bootstrap_icon('box-arrow-up-right') }}
-          <span class="visually-hidden">New Window</span>
-        </span>
+          <span class="badge text-bg-dark" title="New Window" aria-label="This page opens in a new window from navigation.">
+            {{ bootstrap_icon('box-arrow-up-right') }}
+          </span>
         {% endif %}
       </li>
     </ol>

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -62,18 +62,6 @@
   {% set preview_page_revision = current_page_revision %}
 {% endif %}
 
-{% macro page_revision_icon(page_revision, current_page_revision) %}
-  {% if page_revision.isPublished %}
-    {% if current_page_revision == page_revision %}
-    {{ bootstrap_badge_primary('Live') }}
-    {% else %}
-    {{ bootstrap_badge_success('Published') }}
-    {% endif %}
-  {% else %}
-    {{ bootstrap_badge_warning('Draft') }}
-  {% endif %}
-{% endmacro %}
-
 {% block actions %}
   {% if page.isPublished %}
     <a href="{{ page_path(page.path) }}" class="btn btn-outline-dark" target="_blank" rel="noopener" data-bypass>
@@ -103,76 +91,7 @@
 {% block main %}
   <h1 class="visually-hidden">{{ page.name }} {{ preview_page_revision }}</h1>
 
-  <div id="select_revision_label" class="fw-bold">Choose Revision:</div>
-  <div class="dropdown d-inline-block mb-4" role="group" aria-labelledby="select_revision_label">
-    <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-      {{ _self.page_revision_icon(preview_page_revision, current_page_revision) }}
-      {{ preview_page_revision }}
-    </button>
-    <ul class="dropdown-menu">
-      {% for page_revision in page.pageRevisions %}
-        <li>
-          <a class="dropdown-item {{ page_revision == preview_page_revision ? 'disabled' : '' }}" href="{{ path('page_view', {id: page.id, revision: page_revision.id}) }}">
-            {{ _self.page_revision_icon(page_revision, current_page_revision) }}
-            {{ page_revision }}
-          </a>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
-
-  {% set show_publish = (not preview_page_revision.isPublished or current_page_revision != preview_page_revision) and is_granted(attributes.page_revision.publish, preview_page_revision) %}
-
-  {% set show_content = is_granted(attributes.page_revision.content, preview_page_revision) %}
-
-  <div class="dropdown d-inline-block mb-4" role="group">
-    <button class="btn btn-sm btn-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-      Revision Actions
-    </button>
-    <ul class="dropdown-menu">
-      {% if is_granted(attributes.page_revision.template, preview_page_revision) %}
-        <li>
-          <a href="{{ path('page_revision_template', {id: preview_page_revision.id}) }}" class="dropdown-item">
-            {{ bootstrap_icon('columns') }}
-            Template
-          </a>
-        </li>
-      {% endif %}
-
-      {% if show_content %}
-        <li>
-          <a href="{{ path('page_revision_content', {id: preview_page_revision.id}) }}" class="dropdown-item">
-            {{ bootstrap_icon('layout-text-sidebar-reverse') }}
-            Content
-          </a>
-        </li>
-      {% endif %}
-
-      {% if show_publish %}
-        <li>
-          {% embed '@OHMediaBackend/embed/form_post_confirm.html.twig' %}
-            {% block form_action %}{{ path('page_revision_publish', {id: preview_page_revision.id}) }}{% endblock %}
-            {% block confirm_message %}Are you sure you want to publish this revision? It will become the new live page!{% endblock %}
-            {% block csrf_name %}publish_page_revision_{{ preview_page_revision.id }}{% endblock %}
-            {% block button_class %}dropdown-item text-bg-success{% endblock %}
-            {% block button_html %}
-              {{ bootstrap_icon('check') }}
-              {{ preview_page_revision.isPublished ? 'Re-Publish' : 'Publish' }}
-            {% endblock %}
-          {% endembed %}
-        </li>
-      {% endif %}
-
-      {% if is_granted(attributes.page_revision.delete, preview_page_revision) %}
-        <li>
-          <a href="{{ path('page_revision_delete', {id: preview_page_revision.id}) }}" class="dropdown-item text-bg-danger" data-confirm="Are you sure you want to delete this revision?">
-            {{ bootstrap_icon('trash') }}
-            Delete
-          </a>
-        </li>
-      {% endif %}
-    </ul>
-  </div>
+  {% include '@OHMediaPage/page/_page_revision_actions.html.twig' %}
 
   <style>
     iframe {

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -95,7 +95,7 @@
   <h1 class="visually-hidden">{{ page.name }} {{ preview_page_revision }}</h1>
 
   <div id="select_revision_label" class="fw-bold">Choose Revision:</div>
-  <div class="dropdown d-inline-block mb-4" role="group" aria-labelledby="select_revision">
+  <div class="dropdown d-inline-block mb-4" role="group" aria-labelledby="select_revision_label">
     <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
       {{ _self.page_revision_icon(preview_page_revision, current_page_revision) }}
       {{ preview_page_revision }}


### PR DESCRIPTION
Add labels to empty `<th>` elements.

Ensure page parent/slug inputs are labelled/described.

Ensure content fields have proper labelling.

Add visually hidden `<h1>` to page view.