### PR TITLE
Feature/page status improvements

### DIFF
--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -361,6 +361,19 @@ class Page
         return $this;
     }
 
+    public function isScheduled(): bool
+    {
+        if (!$this->getPublished()) {
+            return false;
+        }
+
+        if (DateTimeUtil::isPast($this->getPublished())) {
+            return false;
+        }
+
+        return $this->isCurrentPageRevisionPublished();
+    }
+
     public function isPublished(): bool
     {
         if (!$this->getPublished()) {

--- a/templates/page/_page_actions_shared.html.twig
+++ b/templates/page/_page_actions_shared.html.twig
@@ -59,7 +59,7 @@
             {% block form_action %}{{ path('page_unpublish', {id: page.id}) }}{% endblock %}
             {% block confirm_message %}Are you sure you want to unpublish this page?{% endblock %}
             {% block csrf_name %}unpublish_page_{{ page.id }}{% endblock %}
-            {% block button_class %}dropdown-item text-bg-warning{% endblock %}
+            {% block button_class %}dropdown-item text-bg-secondary{% endblock %}
             {% block button_html %}
               {{ bootstrap_icon('arrow-counterclockwise') }}
               Unpublish

--- a/templates/page/_page_revision_actions.html.twig
+++ b/templates/page/_page_revision_actions.html.twig
@@ -6,7 +6,7 @@
     {{ bootstrap_badge_success('Published') }}
     {% endif %}
   {% else %}
-    {{ bootstrap_badge_warning('Draft') }}
+    {{ bootstrap_badge_secondary('Draft') }}
   {% endif %}
 {% endmacro %}
 

--- a/templates/page/page_index.html.twig
+++ b/templates/page/page_index.html.twig
@@ -129,9 +129,11 @@
       {% endif %}
 
       {% if page.isScheduled %}
-        <span class="badge text-bg-warning" data-bs-toggle="tooltip" title="{{ page.published|date('M j, Y g:ia') }}">
-          Scheduled
-        </span>
+        <span
+          class="badge text-bg-warning"
+          data-bs-toggle="tooltip"
+          title="{{ page.published|date('M j, Y g:ia') }}"
+        >Scheduled</span>
       {% elseif page.isPublished %}
         {{ bootstrap_badge_success('Published') }}
       {% else %}

--- a/templates/page/page_index.html.twig
+++ b/templates/page/page_index.html.twig
@@ -75,7 +75,13 @@
           </tbody>
           <tfoot>
             <tr>
-              <td colspan="100%">A page is considered {{ bootstrap_badge_success('Published') }} if both the page itself and at least one of its revisions are published.</td>
+              <td colspan="100%">
+                {{ bootstrap_badge_success('Published') }} - both the page and one of its revisions are published.
+                <br>
+                {{ bootstrap_badge_warning('Scheduled') }} - same as {{ bootstrap_badge_success('Published') }} but the page publish date is in the future.
+                <br>
+                {{ bootstrap_badge_secondary('Draft') }} - the page itself is not published or no revisions are published.
+              </td>
             </tr>
           </tfoot>
         </table>
@@ -122,10 +128,26 @@
         </span>
       {% endif %}
 
-      {% if page.isPublished %}
+      {% if page.isScheduled %}
+        <span class="badge text-bg-warning" data-bs-toggle="tooltip" title="{{ page.published|date('M j, Y g:ia') }}">
+          Scheduled
+        </span>
+      {% elseif page.isPublished %}
         {{ bootstrap_badge_success('Published') }}
       {% else %}
-        {{ bootstrap_badge_warning('Draft') }}
+        {% set is_revision_published = page.isCurrentPageRevisionPublished %}
+
+        {% if not page.published and not is_revision_published %}
+          {% set tooltip = 'Page and revision not published.' %}
+        {% elseif not page.published %}
+          {% set tooltip = 'Page not published.' %}
+        {% else %}
+          {% set tooltip = 'Revision not published.' %}
+        {% endif %}
+
+        <span class="badge text-bg-secondary" data-bs-toggle="tooltip" title="{{ tooltip }}">
+          Draft
+        </span>
       {% endif %}
 
       {% if page.isHidden %}

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -15,19 +15,7 @@
           </span>
         {% endif %}
 
-        {% if page.isScheduled %}
-          <span class="badge text-bg-warning" title="Scheduled">
-            {{ page.name }}
-          </span>
-        {% elseif page.isPublished %}
-          <span class="badge text-bg-success" title="Published">
-            {{ page.name }}
-          </span>
-        {% else %}
-          <span class="badge text-bg-secondary" title="Draft">
-            {{ page.name }}
-          </span>
-        {% endif %}
+        {{ page.name }}
 
         {% if page.isHidden %}
           <span class="badge text-bg-dark" title="Hidden" aria-label="This page is hidden from navigation.">
@@ -94,6 +82,17 @@
 
 {% block main %}
   <h1 class="visually-hidden">{{ page.name }} {{ preview_page_revision }}</h1>
+
+  {% if page.isScheduled %}
+    <div class="alert alert-warning">
+      This page is scheduled to be published on {{ page.published|date('M j, Y') }} at {{ page.published|date('g:ia') }}.
+      {% if is_granted(attributes.page.edit, page) %}
+        You can edit that date
+        <a href="{{ path('page_edit', {id: page.id}) }}">here</a>.
+      </li>
+    {% endif %}
+    </div>
+  {% endif %}
 
   {% include '@OHMediaPage/page/_page_revision_actions.html.twig' %}
 

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -15,12 +15,16 @@
           </span>
         {% endif %}
 
-        {% if page.isPublished %}
+        {% if page.isScheduled %}
+          <span class="badge text-bg-warning" title="Scheduled">
+            {{ page.name }}
+          </span>
+        {% elseif page.isPublished %}
           <span class="badge text-bg-success" title="Published">
             {{ page.name }}
           </span>
         {% else %}
-          <span class="badge text-bg-warning" title="Draft">
+          <span class="badge text-bg-secondary" title="Draft">
             {{ page.name }}
           </span>
         {% endif %}

--- a/templates/page/page_view.html.twig
+++ b/templates/page/page_view.html.twig
@@ -89,8 +89,7 @@
       {% if is_granted(attributes.page.edit, page) %}
         You can edit that date
         <a href="{{ path('page_edit', {id: page.id}) }}">here</a>.
-      </li>
-    {% endif %}
+      {% endif %}
     </div>
   {% endif %}
 


### PR DESCRIPTION
Updated page listing to have Scheduled (yellow) and Draft (grey) like everything else, with some tooltips for added information. Especially around Draft because it could be the page or the revisions.